### PR TITLE
Feat-large-file-s3

### DIFF
--- a/src/Storage/Device.php
+++ b/src/Storage/Device.php
@@ -55,12 +55,13 @@ abstract class Device
      * @param int $chunk
      * @param int $chunks
      * @param string $tmp
+     * @param array $metadata
      * 
      * @throws \Exception
      *
      * @return int
      */
-    abstract public function upload($source, $path, $chunk = 1, $chunks = 1): int;
+    abstract public function upload($source, $path, $chunk = 1, $chunks = 1, &$metadata = []): int;
 
     /**
      * Read file by given path.

--- a/src/Storage/Device/S3.php
+++ b/src/Storage/Device/S3.php
@@ -169,39 +169,31 @@ class S3 extends Device
      *
      * @param string $source
      * @param string $path
+     * @param int chunk
+     * @param int chunks
+     * @param array $metadata
      *
      * @throws \Exception
      *
      * @return int
      */
-    public function upload($source, $path, $chunk = 1, $chunks = 1): int
+    public function upload($source, $path, $chunk = 1, $chunks = 1, &$metadata = []): int
     {
-        return $this->write($path, \file_get_contents($source), \mime_content_type($source));
-    }
-
-    public function uploadPart($source, $path, $uploadId, $chunk = 1, $chunks = 1): bool
-    {
-        $path = $path . '?partNumber=' . $chunk . '&uploadId=' . $uploadId;
-        $written = $this->write($path, \file_get_contents($source), \mime_content_type($source));
-        if($written && $chunks == $chunk){ // if last chunk
-            $this->completeMultipartUpload($path, $uploadId);
+        $uploadId = $metadata['uploadId'] ?? null;
+        if(empty($uploadId)) {
+            $uploadId = $this->createMultipartUpload($path, $metadata['content_type']);
+            $metadata['uploadId'] = $uploadId;
         }
-        return $written;
-    }
 
-    /**
-     * Complete Multipart Upload
-     * 
-     * @param string $path
-     * @param string $uploadId
-     * 
-     * @return bool
-     */
-    public function completeMultipartUpload($path, $uploadId): bool
-    {
-        $path = $path . '?uploadId=' . $uploadId;
-        $this->call(self::METHOD_POST, $path, '<CompleteMultipartUpload></CompleteMultipartUpload>');
-        return true;
+        $etag = $this->uploadPart($source, $path, $chunk, $uploadId);
+        $metadata['parts'] ??= [];
+        $metadata['parts'][] = ['partNumber' => $chunk, 'etag' => $etag];
+        $metadata['chunks'] ??= 0;
+        $metadata['chunks']++;
+        if($metadata['chunks'] == $chunks) {
+            $this->completeMultipartUpload($path, $uploadId, $metadata['parts']);
+        }
+        return $metadata['chunks'];
     }
 
     /**
@@ -214,17 +206,85 @@ class S3 extends Device
      * 
      * @return string
      */
-    public function startMultipartUpload(string $path, string $contentType): string
+    public function createMultipartUpload(string $path, string $contentType): string
     {
+        $uri = $path !== '' ? '/' . \str_replace(['%2F', '%3F'], ['/', '?'], \rawurlencode($path)) : '/';
+
         $this->headers['date'] = gmdate('D, d M Y H:i:s T');
-        $this->headers['content-md5'] = '';
         $this->headers['content-type'] = $contentType;
         $this->amzHeaders['x-amz-acl'] = $this->acl;
-        $response = $this->call(self::METHOD_POST, $path);
-        var_dump($response);
-        return $response['UploadId'];
+        $response = $this->call(self::METHOD_POST, $uri, '', ['uploads' => '']);
+        return $response->body['UploadId'];
     }
 
+    /**
+     * Upload Part
+     * 
+     * @param string $source
+     * @param string $path
+     * @param string $uploadId
+     * @param int $chunk
+     * 
+     * @return string
+     */
+    protected function uploadPart($source, $path, $chunk, $uploadId) : string
+    {
+        $uri = $path !== '' ? '/' . \str_replace(['%2F', '%3F'], ['/', '?'], \rawurlencode($path)) : '/';
+        
+        $data = \file_get_contents($source);
+        $this->headers['date'] = \gmdate('D, d M Y H:i:s T');
+        $this->headers['content-type'] = \mime_content_type($source);
+        $this->headers['content-md5'] = \base64_encode(md5($data, true)); //TODO whould this work well with big file? can we skip it?
+        $this->amzHeaders['x-amz-content-sha256'] = \hash('sha256', $data);
+        unset($this->amzHeaders['x-amz-acl']);
+
+        $response = $this->call(self::METHOD_PUT, $uri, $data, [
+            'partNumber'=>$chunk,
+            'uploadId' => $uploadId
+        ]);
+
+        return $response->headers['etag'];
+    }
+
+    /**
+     * Complete Multipart Upload
+     * 
+     * @param string $path
+     * @param string $uploadId
+     * 
+     * @return bool
+     */
+    protected function completeMultipartUpload(string $path, string $uploadId, array $parts): bool
+    {
+        $uri = $path !== '' ? '/' . \str_replace(['%2F', '%3F'], ['/', '?'], \rawurlencode($path)) : '/';
+
+        $body = '<CompleteMultipartUpload>';
+        foreach ($parts as $part) {
+            $body .= "<Part><ETag>{$part['etag']}</ETag><PartNumber>{$part['partNumber']}</PartNumber></Part>";
+        }
+        $body .= '</CompleteMultipartUpload>';
+
+        $this->amzHeaders['x-amz-content-sha256'] = \hash('sha256', $body);
+        $this->headers['content-md5'] = \base64_encode(md5($body, true));
+        $this->headers['date'] = \gmdate('D, d M Y H:i:s T');
+        $this->call(self::METHOD_POST, $uri, $body , ['uploadId' => $uploadId]);
+        return true;
+    }
+
+    /**
+     * Abort Multipart Upload
+     * 
+     * @param string $path
+     * @param string $uploadId
+     * 
+     * @return bool
+     */
+    protected function abortMultipartUpload(string $path, string $uploadId): bool
+    {
+        $uri = $path !== '' ? '/' . \str_replace(['%2F', '%3F'], ['/', '?'], \rawurlencode($path)) : '/';
+        $this->call(self::METHOD_DELETE, $uri, '', ['uploadId' => $uploadId]);
+        return true;
+    }
 
     /**
      * Read file by given path.
@@ -254,7 +314,7 @@ class S3 extends Device
      */
     public function write(string $path, string $data, string $contentType = ''): bool
     {
-        $uri = $path !== '' ? '/' . \str_replace('%2F', '/', \rawurlencode($path)) : '/';
+        $uri = $path !== '' ? '/' . \str_replace(['%2F', '%3F'], ['/', '?'], \rawurlencode($path)) : '/';
         
         $this->headers['date'] = \gmdate('D, d M Y H:i:s T');
         $this->headers['content-type'] = $contentType;
@@ -445,7 +505,7 @@ class S3 extends Device
      * @param string $uri
      * @return string
      */
-    private function getSignatureV4(string $method, string $uri): string
+    private function getSignatureV4(string $method, string $uri, $parameters = []): string
     {
         $service = 's3';
         $region = $this->region;
@@ -467,7 +527,6 @@ class S3 extends Device
         uksort($combinedHeaders, [ & $this, 'sortMetaHeadersCmp']);
 
         // Convert null query string parameters to strings and sort
-        $parameters = [];
         uksort($parameters, [ & $this, 'sortMetaHeadersCmp']);
         $queryString = \http_build_query($parameters, '', '&', PHP_QUERY_RFC3986);
 
@@ -517,9 +576,9 @@ class S3 extends Device
      *
      * @return  object
      */
-    private function call(string $method, string $uri, string $data = '')
+    private function call(string $method, string $uri, string $data = '', array $parameters=[])
     {
-        $url = 'https://' . $this->headers['host'] . $uri;
+        $url = 'https://' . $this->headers['host'] . $uri . '?' . \http_build_query($parameters, '', '&', PHP_QUERY_RFC3986);
         $response = new \stdClass;
         $response->body = '';
         $response->headers = [];
@@ -549,7 +608,7 @@ class S3 extends Device
             }
         }
 
-        $httpHeaders[] = 'Authorization: ' . $this->getSignatureV4($method, $uri);
+        $httpHeaders[] = 'Authorization: ' . $this->getSignatureV4($method, $uri, $parameters);
 
         \curl_setopt($curl, CURLOPT_HTTPHEADER, $httpHeaders);
         \curl_setopt($curl, CURLOPT_HEADER, false);
@@ -599,8 +658,9 @@ class S3 extends Device
         \curl_close($curl);
 
         // Parse body into XML
-        if (isset($response->headers['content-type']) && $response->headers['content-type'] == 'application/xml') {
+        if ((isset($response->headers['content-type']) && $response->headers['content-type'] == 'application/xml') || (str_starts_with($response->body, '<?xml'))) {
             $response->body = \simplexml_load_string($response->body);
+            $response->body = json_decode(json_encode($response->body), true);
         }
 
         return $response;

--- a/src/Storage/Device/S3.php
+++ b/src/Storage/Device/S3.php
@@ -237,7 +237,7 @@ class S3 extends Device
         $data = \file_get_contents($source);
         $this->headers['date'] = \gmdate('D, d M Y H:i:s T');
         $this->headers['content-type'] = \mime_content_type($source);
-        $this->headers['content-md5'] = \base64_encode(md5($data, true)); //TODO whould this work well with big file? can we skip it?
+        $this->headers['content-md5'] = \base64_encode(md5($data, true));
         $this->amzHeaders['x-amz-content-sha256'] = \hash('sha256', $data);
         unset($this->amzHeaders['x-amz-acl']);
 

--- a/src/Storage/Device/S3.php
+++ b/src/Storage/Device/S3.php
@@ -209,7 +209,7 @@ class S3 extends Device
      * 
      * @return string
      */
-    public function createMultipartUpload(string $path, string $contentType): string
+    protected function createMultipartUpload(string $path, string $contentType): string
     {
         $uri = $path !== '' ? '/' . \str_replace(['%2F', '%3F'], ['/', '?'], \rawurlencode($path)) : '/';
 

--- a/src/Storage/Device/S3.php
+++ b/src/Storage/Device/S3.php
@@ -239,7 +239,7 @@ class S3 extends Device
         $this->headers['content-type'] = \mime_content_type($source);
         $this->headers['content-md5'] = \base64_encode(md5($data, true));
         $this->amzHeaders['x-amz-content-sha256'] = \hash('sha256', $data);
-        unset($this->amzHeaders['x-amz-acl']);
+        unset($this->amzHeaders['x-amz-acl']); // ACL header is not allowed in parts, only createMultipartUpload accepts this header.
 
         $response = $this->call(self::METHOD_PUT, $uri, $data, [
             'partNumber'=>$chunk,

--- a/src/Storage/Device/S3.php
+++ b/src/Storage/Device/S3.php
@@ -301,8 +301,11 @@ class S3 extends Device
     public function read(string $path, int $offset = 0, int $length = null): string
     {
         $uri = ($path !== '') ? '/' . \str_replace('%2F', '/', \rawurlencode($path)) : '/';
+        if($length !== null) {
+            $end = $offset + $length - 1;
+            $this->headers['range'] = "bytes=$offset-$end";
+        }
         $response = $this->call(self::METHOD_GET, $uri);
-
         return $response->body;
     }
 

--- a/src/Storage/Device/S3.php
+++ b/src/Storage/Device/S3.php
@@ -179,6 +179,9 @@ class S3 extends Device
      */
     public function upload($source, $path, $chunk = 1, $chunks = 1, &$metadata = []): int
     {
+        if($chunk == 1 && $chunks == 1) {
+            return $this->write($path, \file_get_contents($source), \mime_content_type($source));
+        }
         $uploadId = $metadata['uploadId'] ?? null;
         if(empty($uploadId)) {
             $uploadId = $this->createMultipartUpload($path, $metadata['content_type']);

--- a/tests/Storage/Device/DoSpacesTest.php
+++ b/tests/Storage/Device/DoSpacesTest.php
@@ -137,4 +137,49 @@ class DoSpacesTest extends TestCase
     {
         $this->assertEquals(-1, $this->object->getPartitionTotalSpace());
     }
+
+    public function testPartUpload() {
+        $source = __DIR__ . "/../../resources/disk-a/large_file.mp4";
+        $dest = $this->object->getPath('uploaded.mp4');
+        $totalSize = \filesize($source);
+        // AWS S3 requires each part to be at least 5MB except for last part
+        $chunkSize = 5*1024*1024;
+
+        $chunks = ceil($totalSize / $chunkSize);
+
+        $chunk = 1;
+        $start = 0;
+
+        $metadata = [
+            'parts' => [],
+            'chunks' => 0,
+            'uploadId' => null,
+            'content_type' => \mime_content_type($source),
+        ];
+        $handle = @fopen($source, "rb");
+        while ($start < $totalSize) {
+            $contents = fread($handle, $chunkSize);
+            $op = __DIR__ . '/chunk.part';
+            $cc = fopen($op, 'wb');
+            fwrite($cc, $contents);
+            fclose($cc);
+            $etag = $this->object->upload($op, $dest, $chunk, $chunks, $metadata);
+            $parts[] = ['partNumber' => $chunk, 'etag' => $etag];
+            $start += strlen($contents);
+            $chunk++;
+            fseek($handle, $start);
+        }
+        @fclose($handle);
+        unlink($op);
+
+        $this->assertEquals(\filesize($source), $this->object->getFileSize($dest));
+
+        // S3 doesnt provide a method to get a proper MD5-hash of a file created using multipart upload
+        // https://stackoverflow.com/questions/8618218/amazon-s3-checksum
+        // More info on how AWS calculates ETag for multipart upload here
+        // https://savjee.be/2015/10/Verifying-Amazon-S3-multi-part-uploads-with-ETag-hash/
+        // TODO
+        // $this->assertEquals(\md5_file($source), $this->object->getFileHash($dest));
+        $this->object->delete($dest);
+    }
 }

--- a/tests/Storage/Device/LocalTest.php
+++ b/tests/Storage/Device/LocalTest.php
@@ -146,7 +146,18 @@ class LocalTest extends TestCase
         @fclose($handle);
         $this->assertEquals(\filesize($source), $this->object->getFileSize($dest));
         $this->assertEquals(\md5_file($source), $this->object->getFileHash($dest));
-        $this->object->delete($dest);
+        return $dest;
+    }
+
+    /**
+     * @depends testPartUpload
+     */
+    public function testPartRead($path) {
+        $source = __DIR__ . "/../../resources/disk-a/large_file.mp4";
+        $chunk = file_get_contents($source, false,null, 0, 500);
+        $readChunk = $this->object->read($path, 0, 500);
+        $this->assertEquals($chunk, $readChunk);
+        $this->object->delete($path);
     }
     
     public function testPartitionFreeSpace()

--- a/tests/Storage/Device/S3Test.php
+++ b/tests/Storage/Device/S3Test.php
@@ -186,6 +186,18 @@ class S3Test extends TestCase
         // https://savjee.be/2015/10/Verifying-Amazon-S3-multi-part-uploads-with-ETag-hash/
         // TODO
         // $this->assertEquals(\md5_file($source), $this->object->getFileHash($dest));
-        $this->object->delete($dest);
+        // $this->object->delete($dest);
+        return $dest;
+    }
+
+    /**
+     * @depends testPartUpload
+     */
+    public function testPartRead($path) {
+        $source = __DIR__ . "/../../resources/disk-a/large_file.mp4";
+        $chunk = file_get_contents($source, false,null, 0, 500);
+        $readChunk = $this->object->read($path, 0, 500);
+        $this->assertEquals($chunk, $readChunk);
+        $this->object->delete($path);
     }
 }

--- a/tests/Storage/Device/S3Test.php
+++ b/tests/Storage/Device/S3Test.php
@@ -143,4 +143,49 @@ class S3Test extends TestCase
     {
         $this->assertEquals(-1, $this->object->getPartitionTotalSpace());
     }
+
+    public function testPartUpload() {
+        $source = __DIR__ . "/../../resources/disk-a/large_file.mp4";
+        $dest = $this->object->getPath('uploaded.mp4');
+        $totalSize = \filesize($source);
+        // AWS S3 requires each part to be at least 5MB except for last part
+        $chunkSize = 5*1024*1024;
+
+        $chunks = ceil($totalSize / $chunkSize);
+
+        $chunk = 1;
+        $start = 0;
+
+        $metadata = [
+            'parts' => [],
+            'chunks' => 0,
+            'uploadId' => null,
+            'content_type' => \mime_content_type($source),
+        ];
+        $handle = @fopen($source, "rb");
+        while ($start < $totalSize) {
+            $contents = fread($handle, $chunkSize);
+            $op = __DIR__ . '/chunk.part';
+            $cc = fopen($op, 'wb');
+            fwrite($cc, $contents);
+            fclose($cc);
+            $etag = $this->object->upload($op, $dest, $chunk, $chunks, $metadata);
+            $parts[] = ['partNumber' => $chunk, 'etag' => $etag];
+            $start += strlen($contents);
+            $chunk++;
+            fseek($handle, $start);
+        }
+        @fclose($handle);
+        unlink($op);
+
+        $this->assertEquals(\filesize($source), $this->object->getFileSize($dest));
+
+        // S3 doesnt provide a method to get a proper MD5-hash of a file created using multipart upload
+        // https://stackoverflow.com/questions/8618218/amazon-s3-checksum
+        // More info on how AWS calculates ETag for multipart upload here
+        // https://savjee.be/2015/10/Verifying-Amazon-S3-multi-part-uploads-with-ETag-hash/
+        // TODO
+        // $this->assertEquals(\md5_file($source), $this->object->getFileHash($dest));
+        $this->object->delete($dest);
+    }
 }

--- a/tests/Storage/Device/S3Test.php
+++ b/tests/Storage/Device/S3Test.php
@@ -163,6 +163,7 @@ class S3Test extends TestCase
             'content_type' => \mime_content_type($source),
         ];
         $handle = @fopen($source, "rb");
+        $op = __DIR__ . '/chunk.part';
         while ($start < $totalSize) {
             $contents = fread($handle, $chunkSize);
             $op = __DIR__ . '/chunk.part';


### PR DESCRIPTION
Large file upload in S3 using multipart upload

1. The interface is still the same.
2. MultipartUpload to S3 is handled internally

## Open Question
1. Should we expose `abortMultipartUpload`, if user doesn't want to complete or while clearing incomplete multipart upload, user needs to call `abortMultipartUpload` to remove the parts that are already uploaded otherwise they will be charged for those storage until they abort?
2. Handling if some of the part fails uploading, do we handle internally? 
3. S3 has a limitation that each chunk must be at least 5MB (except for last), chunks smaller than 5MB is not allowed for multipart upload, so we need to handle this in Appwrite.