### PR TITLE
Replace move_uploaded_file with rename function

### DIFF
--- a/src/Storage/Device/Local.php
+++ b/src/Storage/Device/Local.php
@@ -82,7 +82,7 @@ class Local extends Device
             }
         }
 
-        if (\move_uploaded_file($source, $path)) {
+        if (\rename($source, $path)) {
             return true;
         }
 


### PR DESCRIPTION
This PR will replace the `move_uploaded_file` used in the upload function of the Local Adapter with `rename` so files that were not created using PHP's upload system such as function build tarballs can be uploaded to the local storage adapter.