### PR TITLE
Fix: DigitalOcean name

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ require_once '../vendor/autoload.php';
 use Utopia\Storage\Storage;
 use Utopia\Storage\Device\Local
 use Utopia\Storage\Device\S3
-use Utopia\Storage\Device\DoSpaces
+use Utopia\Storage\Device\DOSpaces
 
 // instiantiating local storage
 Storage::setDevice('files', new Local('path'));
@@ -33,7 +33,7 @@ Storage::setDevice('files', new Local('path'));
 Storage::setDevice('files', new S3('path',AWS_ACCESS_KEY, AWS_SECRET_KEY,AWS_BUCKET_NAME, AWS_REGION, AWS_ACL_FLAG));
 
 //or you can use Digitalocean spaces storage
-Storage::setDevice('files', new DoSpaces('path',DO_SPACES_ACCESS_KEY, DO_SPACES_SECRET_KEY,DO_SPACES_BUCKET_NAME, DO_SPACES_REGION, AWS_ACL_FLAG));
+Storage::setDevice('files', new DOSpaces('path',DO_SPACES_ACCESS_KEY, DO_SPACES_SECRET_KEY,DO_SPACES_BUCKET_NAME, DO_SPACES_REGION, AWS_ACL_FLAG));
 
 $device = Storage::getDevice('files');
 

--- a/src/Storage/Device/DOSpaces.php
+++ b/src/Storage/Device/DOSpaces.php
@@ -4,7 +4,7 @@ namespace Utopia\Storage\Device;
 
 use Utopia\Storage\Device\S3;
 
-class DoSpaces extends S3
+class DOSpaces extends S3
 {
     /**
      * Regions constants
@@ -18,7 +18,7 @@ class DoSpaces extends S3
     const AMS3 = 'AMS3';
 
     /**
-     * DoSpaces Constructor
+     * DOSpaces Constructor
      *
      * @param string $root
      * @param string $accessKey

--- a/src/Storage/Storage.php
+++ b/src/Storage/Storage.php
@@ -12,7 +12,7 @@ class Storage
      */
     const DEVICE_LOCAL = 'Local';
     const DEVICE_S3 = 'S3';
-    const DEVICE_DO_SPACES = 'DoSpaces';
+    const DEVICE_DO_SPACES = 'DOSpaces';
 
     /**
      * Devices.

--- a/tests/Storage/Device/DOSpacesTest.php
+++ b/tests/Storage/Device/DOSpacesTest.php
@@ -2,10 +2,10 @@
 
 namespace Utopia\Tests;
 
-use Utopia\Storage\Device\DoSpaces;
+use Utopia\Storage\Device\DOSpaces;
 use Utopia\Tests\S3Base;
 
-class DoSpacesTest extends S3Base
+class DOSpacesTest extends S3Base
 {
     protected function init(): void
     {
@@ -14,7 +14,7 @@ class DoSpacesTest extends S3Base
         $secret = $_SERVER['DO_SECRET'] ?? '';
         $bucket = "utopia-storage-tests";
 
-        $this->object = new DoSpaces($this->root, $key, $secret, $bucket, DoSpaces::NYC3, DoSpaces::ACL_PUBLIC_READ);
+        $this->object = new DOSpaces($this->root, $key, $secret, $bucket, DOSpaces::NYC3, DOSpaces::ACL_PUBLIC_READ);
 
     }
 


### PR DESCRIPTION
## What does this PR do?

We use `DoSpaces`, but that would mean it's called `Digital ocean Spaces`. This PR renames that to `DOSpaces`.

## Test Plan

Current tests need to pass.

## Related PRs and Issues

Appwrite PR: https://github.com/appwrite/appwrite/pull/2760

### Have you read the Contributing Guidelines on issues?

✅
