### PR TITLE
Fix chunked upload tmp path

### DIFF
--- a/src/Storage/Device/Local.php
+++ b/src/Storage/Device/Local.php
@@ -96,7 +96,7 @@ class Local extends Device
             }
             return $chunks;
         }
-        $tmp = \dirname($path) . DIRECTORY_SEPARATOR . 'tmp' . DIRECTORY_SEPARATOR . \basename($path) . '_chunks.log';
+        $tmp = \dirname($path) . DIRECTORY_SEPARATOR . 'tmp_' . \basename($path) . DIRECTORY_SEPARATOR . \basename($path) . '_chunks.log';
 
         if (!\file_exists(\dirname($tmp))) { // Checks if directory path to file exists
             if (!@\mkdir(\dirname($tmp), 0755, true)) {
@@ -151,7 +151,7 @@ class Local extends Device
             \unlink($path);
         }
 
-        $tmp = \dirname($path) . DIRECTORY_SEPARATOR . 'tmp' . DIRECTORY_SEPARATOR;
+        $tmp = \dirname($path) . DIRECTORY_SEPARATOR . 'tmp_' . \basename($path) . DIRECTORY_SEPARATOR;
 
         if (!\file_exists(\dirname($tmp))) { // Checks if directory path to file exists
             throw new Exception('File doesn\'t exist: ' . \dirname($path));

--- a/tests/Storage/Device/LocalTest.php
+++ b/tests/Storage/Device/LocalTest.php
@@ -149,6 +149,58 @@ class LocalTest extends TestCase
         return $dest;
     }
 
+    public function testAbort() {
+        $source = __DIR__ . '/../../resources/disk-a/large_file.mp4';
+        $dest = $this->object->getPath('abcduploaded.mp4');
+        $totalSize = $this->object->getFileSize($source);
+        $chunkSize = 2097152;
+        $chunks = ceil($totalSize / $chunkSize);
+
+        $chunk = 1;
+        $start = 0;
+
+        $handle = @fopen($source, 'rb');
+        while ($chunk < 3) { // only upload two chunks
+            $contents = fread($handle, $chunkSize);
+            $op = __DIR__ . '/chunk.part';
+            $cc = fopen($op, 'wb');
+            fwrite($cc, $contents);
+            fclose($cc);
+            $this->object->upload($op, $dest, $chunk, $chunks);
+            $start += strlen($contents);
+            $chunk++;
+            fseek($handle, $start);
+        }
+        @fclose($handle);
+
+        // using file name with same first four chars
+        $source = __DIR__ . '/../../resources/disk-a/large_file.mp4';
+        $dest1 = $this->object->getPath('abcduploaded2.mp4');
+        $totalSize = $this->object->getFileSize($source);
+        $chunkSize = 2097152;
+        $chunks = ceil($totalSize / $chunkSize);
+
+        $chunk = 1;
+        $start = 0;
+
+        $handle = @fopen($source, 'rb');
+        while ($chunk < 3) { // only upload two chunks
+            $contents = fread($handle, $chunkSize);
+            $op = __DIR__ . '/chunk.part';
+            $cc = fopen($op, 'wb');
+            fwrite($cc, $contents);
+            fclose($cc);
+            $this->object->upload($op, $dest1, $chunk, $chunks);
+            $start += strlen($contents);
+            $chunk++;
+            fseek($handle, $start);
+        }
+        @fclose($handle);
+        
+        $this->assertTrue($this->object->abort($dest));
+        $this->assertTrue($this->object->abort($dest1));
+    }
+
     /**
      * @depends testPartUpload
      */


### PR DESCRIPTION
- Chunked upload was using `tmp` directory to store logs and chunks in the provided path's parent directory
- If the multiple files had same first four chars, they would use the same parent directory so shared the `tmp` folder
- Abort method remove `tmp` folder so, if two files had tmp files, after aborting the first file, second would not abort
- Fixed by appending file name to the tmp directory name `tmp` now `tmp_filename`
- This occurred mostly with Appwrite's auto generated ID as they seems to share first four chars for a quite some time