### PR TITLE
feat : bring consistency with backblaze naming

### DIFF
--- a/src/Storage/Device/Backblaze.php
+++ b/src/Storage/Device/Backblaze.php
@@ -4,7 +4,7 @@ namespace Utopia\Storage\Device;
 
 use Utopia\Storage\Device\S3;
 
-class BackBlaze extends S3
+class Backblaze extends S3
 {
     /**
      * Regions constants
@@ -20,7 +20,7 @@ class BackBlaze extends S3
     const EU_CENTRAL_004 = 'eu-central-004';
 
     /**
-     * BackBlaze Constructor
+     * Backblaze Constructor
      *
      * @param string $root
      * @param string $accessKey
@@ -40,7 +40,7 @@ class BackBlaze extends S3
      */
     public function getName(): string
     {
-        return 'BackBlaze B2 Storage';
+        return 'Backblaze B2 Storage';
     }
 
     /**
@@ -48,6 +48,6 @@ class BackBlaze extends S3
      */
     public function getDescription(): string
     {
-        return 'BackBlaze B2 Storage';
+        return 'Backblaze B2 Storage';
     }
 }

--- a/src/Storage/Storage.php
+++ b/src/Storage/Storage.php
@@ -14,7 +14,7 @@ class Storage
     const DEVICE_S3 = 'S3';
     const DEVICE_DO_SPACES = 'DOSpaces';
     const DEVICE_WASABI = 'Wasabi';
-    const DEVICE_BACKBLAZE = 'BackBlaze';
+    const DEVICE_BACKBLAZE = 'Backblaze';
     const DEVICE_LINODE= 'Linode';
 
     /**

--- a/tests/Storage/Device/BackblazeTest.php
+++ b/tests/Storage/Device/BackblazeTest.php
@@ -12,7 +12,7 @@ class BackblazeTest extends S3Base
         $this->root = 'root';
         $key = $_SERVER['BACKBLAZE_ACCESS_KEY'] ?? '';
         $secret = $_SERVER['BACKBLAZE_SECRET'] ?? '';
-        $bucket = "backblaze-demo";
+        $bucket = "backblaze-demo-1";
 
         $this->object = new Backblaze($this->root, $key, $secret, $bucket, BackBlaze::US_WEST_004, Backblaze::ACL_PRIVATE);
 

--- a/tests/Storage/Device/BackblazeTest.php
+++ b/tests/Storage/Device/BackblazeTest.php
@@ -2,10 +2,10 @@
 
 namespace Utopia\Tests;
 
-use Utopia\Storage\Device\BackBlaze;
+use Utopia\Storage\Device\Backblaze;
 use Utopia\Tests\S3Base;
 
-class BackBlazeTest extends S3Base
+class BackblazeTest extends S3Base
 {
     protected function init(): void
     {
@@ -14,17 +14,17 @@ class BackBlazeTest extends S3Base
         $secret = $_SERVER['BACKBLAZE_SECRET'] ?? '';
         $bucket = "backblaze-demo";
 
-        $this->object = new BackBlaze($this->root, $key, $secret, $bucket, BackBlaze::US_WEST_004, BackBlaze::ACL_PRIVATE);
+        $this->object = new Backblaze($this->root, $key, $secret, $bucket, BackBlaze::US_WEST_004, Backblaze::ACL_PRIVATE);
 
     }
 
     protected function getAdapterName(): string
     {
-        return 'BackBlaze B2 Storage';
+        return 'Backblaze B2 Storage';
     }
 
     protected function getAdapterDescription(): string
     {
-        return 'BackBlaze B2 Storage';
+        return 'Backblaze B2 Storage';
     }
 }

--- a/tests/Storage/Device/BackblazeTest.php
+++ b/tests/Storage/Device/BackblazeTest.php
@@ -12,9 +12,9 @@ class BackblazeTest extends S3Base
         $this->root = 'root';
         $key = $_SERVER['BACKBLAZE_ACCESS_KEY'] ?? '';
         $secret = $_SERVER['BACKBLAZE_SECRET'] ?? '';
-        $bucket = "backblaze-demo-1";
+        $bucket = "backblaze-demo";
 
-        $this->object = new Backblaze($this->root, $key, $secret, $bucket, BackBlaze:: EU_CENTRAL_003, Backblaze::ACL_PRIVATE);
+        $this->object = new Backblaze($this->root, $key, $secret, $bucket, BackBlaze::US_WEST_004, Backblaze::ACL_PRIVATE);
 
     }
 

--- a/tests/Storage/Device/BackblazeTest.php
+++ b/tests/Storage/Device/BackblazeTest.php
@@ -14,7 +14,7 @@ class BackblazeTest extends S3Base
         $secret = $_SERVER['BACKBLAZE_SECRET'] ?? '';
         $bucket = "backblaze-demo";
 
-        $this->object = new Backblaze($this->root, $key, $secret, $bucket, BackBlaze::US_WEST_004, Backblaze::ACL_PRIVATE);
+        $this->object = new Backblaze($this->root, $key, $secret, $bucket, Backblaze::US_WEST_004, Backblaze::ACL_PRIVATE);
 
     }
 

--- a/tests/Storage/Device/BackblazeTest.php
+++ b/tests/Storage/Device/BackblazeTest.php
@@ -14,7 +14,7 @@ class BackblazeTest extends S3Base
         $secret = $_SERVER['BACKBLAZE_SECRET'] ?? '';
         $bucket = "backblaze-demo-1";
 
-        $this->object = new Backblaze($this->root, $key, $secret, $bucket, BackBlaze::US_WEST_004, Backblaze::ACL_PRIVATE);
+        $this->object = new Backblaze($this->root, $key, $secret, $bucket, BackBlaze:: EU_CENTRAL_003, Backblaze::ACL_PRIVATE);
 
     }
 

--- a/tests/Storage/Device/WasabiTest.php
+++ b/tests/Storage/Device/WasabiTest.php
@@ -12,7 +12,7 @@ class WasabiTest extends S3Base
         $this->root = 'root';
         $key = $_SERVER['WASABI_ACCESS_KEY'] ?? '';
         $secret = $_SERVER['WASABI_SECRET'] ?? '';
-        $bucket = "utopia-tests";
+        $bucket = 'utopia-tests';
 
         $this->object = new Wasabi($this->root, $key, $secret, $bucket, Wasabi::EU_CENTRAL_1, WASABI::ACL_PRIVATE);
 

--- a/tests/Storage/Device/WasabiTest.php
+++ b/tests/Storage/Device/WasabiTest.php
@@ -12,7 +12,7 @@ class WasabiTest extends S3Base
         $this->root = 'root';
         $key = $_SERVER['WASABI_ACCESS_KEY'] ?? '';
         $secret = $_SERVER['WASABI_SECRET'] ?? '';
-        $bucket = "everly-wasabi-test";
+        $bucket = "utopia-tests";
 
         $this->object = new Wasabi($this->root, $key, $secret, $bucket, Wasabi::EU_CENTRAL_1, WASABI::ACL_PRIVATE);
 


### PR DESCRIPTION
This PR introduces consistency with the naming of  the Backblaze adapter

- changes  `BackBlaze`  to `Backblaze` 