### PR TITLE
Fix : Linode File Upload

### DIFF
--- a/src/Storage/Device/Local.php
+++ b/src/Storage/Device/Local.php
@@ -19,7 +19,7 @@ class Local extends Device
      */
     public function __construct($root = '')
     {
-        $this->root = $root;
+        $this->root = trim($root,"/");
     }
 
     /**

--- a/src/Storage/Device/S3.php
+++ b/src/Storage/Device/S3.php
@@ -112,7 +112,7 @@ class S3 extends Device
         $this->secretKey = $secretKey;
         $this->bucket = $bucket;
         $this->region = $region;
-        $this->root = $root;
+        $this->root = trim( $root,"/" );
         $this->acl = $acl;
         $this->headers['host'] = $this->bucket . '.s3.'.$this->region.'.amazonaws.com';
         $this->amzHeaders = [];

--- a/src/Storage/Device/S3.php
+++ b/src/Storage/Device/S3.php
@@ -112,7 +112,7 @@ class S3 extends Device
         $this->secretKey = $secretKey;
         $this->bucket = $bucket;
         $this->region = $region;
-        $this->root = trim( $root,"/" );
+        $this->root = trim($root, "/");
         $this->acl = $acl;
         $this->headers['host'] = $this->bucket . '.s3.'.$this->region.'.amazonaws.com';
         $this->amzHeaders = [];

--- a/tests/Storage/Device/BackblazeTest.php
+++ b/tests/Storage/Device/BackblazeTest.php
@@ -9,7 +9,7 @@ class BackblazeTest extends S3Base
 {
     protected function init(): void
     {
-        $this->root = 'root';
+        $this->root = '/root';
         $key = $_SERVER['BACKBLAZE_ACCESS_KEY'] ?? '';
         $secret = $_SERVER['BACKBLAZE_SECRET'] ?? '';
         $bucket = "backblaze-demo";

--- a/tests/Storage/Device/LinodeTest.php
+++ b/tests/Storage/Device/LinodeTest.php
@@ -9,7 +9,7 @@ class LinodeTest extends S3Base
 {
     protected function init(): void
     {
-        $this->root = 'root';
+        $this->root = '/root';
         $key = $_SERVER['LINODE_ACCESS_KEY'] ?? '';
         $secret = $_SERVER['LINODE_SECRET'] ?? '';
         $bucket = 'everly-test';

--- a/tests/Storage/Device/LocalTest.php
+++ b/tests/Storage/Device/LocalTest.php
@@ -33,12 +33,12 @@ class LocalTest extends TestCase
 
     public function testRoot()
     {
-        $this->assertEquals($this->object->getRoot(),realpath( __DIR__ . '/../../resources/disk-a'));
+        $this->assertEquals($this->object->getRoot(),trim(realpath( __DIR__ . '/../../resources/disk-a'),"/"));
     }
 
     public function testPath()
     {
-        $this->assertEquals($this->object->getPath('image.png'), realpath(__DIR__ . '/../../resources/disk-a').'/image.png');
+        $this->assertEquals($this->object->getPath('image.png'), trim(realpath(__DIR__ . '/../../resources/disk-a').'/image.png',"/"));
     }
 
     public function testWrite()

--- a/tests/Storage/Device/WasabiTest.php
+++ b/tests/Storage/Device/WasabiTest.php
@@ -9,7 +9,7 @@ class WasabiTest extends S3Base
 {
     protected function init(): void
     {
-        $this->root = 'root';
+        $this->root = '/root';
         $key = $_SERVER['WASABI_ACCESS_KEY'] ?? '';
         $secret = $_SERVER['WASABI_SECRET'] ?? '';
         $bucket = 'utopia-storage-tests';

--- a/tests/Storage/S3Base.php
+++ b/tests/Storage/S3Base.php
@@ -68,12 +68,12 @@ abstract class S3Base extends TestCase
 
     public function testRoot()
     {
-        $this->assertEquals($this->root, $this->object->getRoot());
+        $this->assertEquals( trim($this->root, "/"), $this->object->getRoot());
     }
 
     public function testPath()
     {
-        $this->assertEquals($this->root . '/image.png', $this->object->getPath('image.png'));
+        $this->assertEquals(trim($this->root, "/") . '/image.png', $this->object->getPath('image.png'));
     }
 
     public function testWrite()


### PR DESCRIPTION
### Trim extra slashes before passing root.
Doing this because it creates an extra `/` while integrating with Appwrite.
for eg , a call as below was being made.

`https://<bucket-name>.eu-central-1.linodeobjects.com**//**storage/uploads/app-630cd8d7a106aa302d27/630cd8e90d3b33e8ff5c/6/3/0/c/630cdc2875416374d993.jpg`

The root  within Appwrite are already prefixed with  `/` (seen as  below). Hence, we need to trim it here to avoid double slashes.

This PR implements trimming the root in the constructor.
```php
const APP_STORAGE_UPLOADS = '/storage/uploads';
const APP_STORAGE_FUNCTIONS = '/storage/functions';
const APP_STORAGE_BUILDS = '/storage/builds';
const APP_STORAGE_CACHE = '/storage/cache';
const APP_STORAGE_CERTIFICATES = '/storage/certificates';
const APP_STORAGE_CONFIG = '/storage/config';
```