### PR TITLE
Add BZIP2 compression algorithm

### DIFF
--- a/src/Storage/Compression/Algorithms/BZIP2.php
+++ b/src/Storage/Compression/Algorithms/BZIP2.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Utopia\Storage\Compression\Algorithms;
+
+use Utopia\Storage\Compression\Compression;
+
+class BZIP2 extends Compression
+{
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'bzip2';
+    }
+
+    /**
+     * Compress.
+     *
+     * @see https://www.php.net/manual/en/function.bzcompress.php
+     *
+     * @param string $data
+     * @return string
+     */
+    public function compress(string $data): string
+    {
+        return \bzcompress($data);
+    }
+
+    /**
+     * Decompress.
+     *
+     * @see https://www.php.net/manual/en/function.bzdecompress.php
+     *
+     * @param string $data
+     * @return string
+     */
+    public function decompress(string $data):string
+    {
+        return \bzdecompress($data);
+    }
+}

--- a/tests/Storage/Compression/Algorithms/BZIP2Test.php
+++ b/tests/Storage/Compression/Algorithms/BZIP2Test.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Utopia\Tests;
+
+use Utopia\Storage\Compression\Algorithms\BZIP2;
+use PHPUnit\Framework\TestCase;
+
+class BZIP2Test extends TestCase
+{
+    /** @var BZIP2 */
+    protected BZIP2 $object;
+
+    public function setUp(): void
+    {
+        $this->object = new BZIP2();
+    }
+
+    public function testName()
+    {
+        $this->assertEquals($this->object->getName(), 'bzip2');
+    }
+
+    public function testCompressDecompressWithText()
+    {
+        $demo = 'This is a demo string';
+        $demoSize = mb_strlen($demo, '8bit');
+
+        $data = $this->object->compress($demo);
+        $dataSize = mb_strlen($data, '8bit');
+
+        $this->assertEquals($demoSize, 21);
+        $this->assertEquals($dataSize, 58);
+
+        $this->assertEquals($this->object->decompress($data), $demo);
+    }
+
+    public function testCompressDecompressWithJPGImage()
+    {
+        $demo = \file_get_contents(__DIR__ . '/../../../resources/disk-a/kitten-1.jpg');
+        $demoSize = mb_strlen($demo, '8bit');
+
+        $data = $this->object->compress($demo);
+        $dataSize = mb_strlen($data, '8bit');
+
+        $this->assertEquals($demoSize, 599639);
+        $this->assertEquals($dataSize, 598565);
+
+        $this->assertGreaterThan($dataSize, $demoSize);
+
+        $data = $this->object->decompress($data);
+        $dataSize = mb_strlen($data, '8bit');
+
+        $this->assertEquals($dataSize, 599639);
+    }
+
+    public function testCompressDecompressWithPNGImage()
+    {
+        $demo = \file_get_contents(__DIR__ . '/../../../resources/disk-b/kitten-1.png');
+        $demoSize = mb_strlen($demo, '8bit');
+
+        $data = $this->object->compress($demo);
+        $dataSize = mb_strlen($data, '8bit');
+
+        $this->assertEquals($demoSize, 3038056);
+        $this->assertEquals($dataSize, 2999345);
+
+        $this->assertGreaterThan($dataSize, $demoSize);
+
+        $data = $this->object->decompress($data);
+        $dataSize = mb_strlen($data, '8bit');
+
+        $this->assertEquals($dataSize, 3038056);
+    }
+}


### PR DESCRIPTION
Creates a new compression class to support BZIP2 compression and decompression, with accompanied unit test.

```
➜  utopia-php-storage git:(feat-bzip2-compression) ✗ ./vendor/bin/phpunit --filter BZIP2Test
PHPUnit 9.5.25 by Sebastian Bergmann and contributors.

....                                                                4 / 4 (100%)

Time: 00:01.870, Memory: 17.55 MB

OK (4 tests, 12 assertions)
```

Part 1 of https://github.com/appwrite/appwrite/issues/3996