### PR TITLE
feat: add get type method

### DIFF
--- a/src/Storage/Device.php
+++ b/src/Storage/Device.php
@@ -16,6 +16,15 @@ abstract class Device
     abstract public function getName(): string;
 
     /**
+     * Get Type.
+     *
+     * Get storage device type
+     *
+     * @return string
+     */
+    abstract public function getType(): string;
+
+    /**
      * Get Description.
      *
      * Get storage device description and purpose.

--- a/src/Storage/Device/Backblaze.php
+++ b/src/Storage/Device/Backblaze.php
@@ -49,4 +49,12 @@ class Backblaze extends S3
     {
         return 'Backblaze B2 Storage';
     }
+
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return Storage::DEVICE_BACKBLAZE;
+    }
 }

--- a/src/Storage/Device/Backblaze.php
+++ b/src/Storage/Device/Backblaze.php
@@ -3,6 +3,7 @@
 namespace Utopia\Storage\Device;
 
 use Utopia\Storage\Device\S3;
+use Utopia\Storage\Storage;
 
 class Backblaze extends S3
 {

--- a/src/Storage/Device/DOSpaces.php
+++ b/src/Storage/Device/DOSpaces.php
@@ -3,6 +3,7 @@
 namespace Utopia\Storage\Device;
 
 use Utopia\Storage\Device\S3;
+use Utopia\Storage\Storage;
 
 class DOSpaces extends S3
 {

--- a/src/Storage/Device/DOSpaces.php
+++ b/src/Storage/Device/DOSpaces.php
@@ -48,4 +48,12 @@ class DOSpaces extends S3
     {
         return 'Digitalocean Spaces Storage';
     }
+
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return Storage::DEVICE_DO_SPACES;
+    }
 }

--- a/src/Storage/Device/Linode.php
+++ b/src/Storage/Device/Linode.php
@@ -47,4 +47,12 @@ class Linode extends S3
     {
         return 'Linode Object Storage';
     }
+
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return Storage::DEVICE_LINODE;
+    }
 }

--- a/src/Storage/Device/Linode.php
+++ b/src/Storage/Device/Linode.php
@@ -3,6 +3,7 @@
 namespace Utopia\Storage\Device;
 
 use Utopia\Storage\Device\S3;
+use Utopia\Storage\Storage;
 
 class Linode extends S3
 {

--- a/src/Storage/Device/Local.php
+++ b/src/Storage/Device/Local.php
@@ -33,6 +33,14 @@ class Local extends Device
     /**
      * @return string
      */
+    public function getType(): string
+    {
+        return Storage::DEVICE_LOCAL;
+    }
+
+    /**
+     * @return string
+     */
     public function getDescription(): string
     {
         return 'Adapter for Local storage that is in the physical or virtual machine or mounted to it.';

--- a/src/Storage/Device/Local.php
+++ b/src/Storage/Device/Local.php
@@ -4,6 +4,7 @@ namespace Utopia\Storage\Device;
 
 use Exception;
 use Utopia\Storage\Device;
+use Utopia\Storage\Storage;
 
 class Local extends Device
 {

--- a/src/Storage/Device/S3.php
+++ b/src/Storage/Device/S3.php
@@ -129,6 +129,14 @@ class S3 extends Device
     /**
      * @return string
      */
+    public function getType(): string
+    {
+        return Storage::DEVICE_S3;
+    }
+
+    /**
+     * @return string
+     */
     public function getDescription(): string
     {
         return 'S3 Bucket Storage drive for AWS or on premise solution';

--- a/src/Storage/Device/S3.php
+++ b/src/Storage/Device/S3.php
@@ -4,6 +4,7 @@ namespace Utopia\Storage\Device;
 
 use Exception;
 use Utopia\Storage\Device;
+use Utopia\Storage\Storage;
 
 class S3 extends Device
 {

--- a/src/Storage/Device/Wasabi.php
+++ b/src/Storage/Device/Wasabi.php
@@ -3,6 +3,7 @@
 namespace Utopia\Storage\Device;
 
 use Utopia\Storage\Device\S3;
+use Utopia\Storage\Storage;
 
 class Wasabi extends S3
 {

--- a/src/Storage/Device/Wasabi.php
+++ b/src/Storage/Device/Wasabi.php
@@ -53,4 +53,12 @@ class Wasabi extends S3
     {
         return 'Wasabi Storage';
     }
+
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return Storage::DEVICE_WASABI;
+    }
 }

--- a/src/Storage/Storage.php
+++ b/src/Storage/Storage.php
@@ -10,12 +10,12 @@ class Storage
     /**
      * Supported devices
      */
-    const DEVICE_LOCAL = 'Local';
-    const DEVICE_S3 = 'S3';
-    const DEVICE_DO_SPACES = 'DOSpaces';
-    const DEVICE_WASABI = 'Wasabi';
-    const DEVICE_BACKBLAZE = 'Backblaze';
-    const DEVICE_LINODE= 'Linode';
+    const DEVICE_LOCAL = 'local';
+    const DEVICE_S3 = 's3';
+    const DEVICE_DO_SPACES = 'dospaces';
+    const DEVICE_WASABI = 'wasabi';
+    const DEVICE_BACKBLAZE = 'backblaze';
+    const DEVICE_LINODE= 'linode';
 
     /**
      * Devices.

--- a/tests/Storage/Device/BackblazeTest.php
+++ b/tests/Storage/Device/BackblazeTest.php
@@ -25,7 +25,7 @@ class BackblazeTest extends S3Base
 
     protected function getAdapterType(): string
     {
-        return this->object->getType();
+        return $this->object->getType();
     }
 
     protected function getAdapterDescription(): string

--- a/tests/Storage/Device/BackblazeTest.php
+++ b/tests/Storage/Device/BackblazeTest.php
@@ -23,6 +23,11 @@ class BackblazeTest extends S3Base
         return 'Backblaze B2 Storage';
     }
 
+    protected function getAdapterType(): string
+    {
+        return this->object->getType();
+    }
+
     protected function getAdapterDescription(): string
     {
         return 'Backblaze B2 Storage';

--- a/tests/Storage/Device/DOSpacesTest.php
+++ b/tests/Storage/Device/DOSpacesTest.php
@@ -23,6 +23,11 @@ class DOSpacesTest extends S3Base
         return 'Digitalocean Spaces Storage';
     }
 
+    protected function getAdapterType(): string
+    {
+        return this->object->getType();
+    }
+    
     protected function getAdapterDescription(): string
     {
         return 'Digitalocean Spaces Storage';

--- a/tests/Storage/Device/DOSpacesTest.php
+++ b/tests/Storage/Device/DOSpacesTest.php
@@ -25,7 +25,7 @@ class DOSpacesTest extends S3Base
 
     protected function getAdapterType(): string
     {
-        return this->object->getType();
+        return $this->object->getType();
     }
     
     protected function getAdapterDescription(): string

--- a/tests/Storage/Device/LinodeTest.php
+++ b/tests/Storage/Device/LinodeTest.php
@@ -23,6 +23,11 @@ class LinodeTest extends S3Base
         return 'Linode Object Storage';
     }
 
+    protected function getAdapterType(): string
+    {
+        return this->object->getType();
+    }
+
     protected function getAdapterDescription(): string
     {
         return 'Linode Object Storage';

--- a/tests/Storage/Device/LinodeTest.php
+++ b/tests/Storage/Device/LinodeTest.php
@@ -25,7 +25,7 @@ class LinodeTest extends S3Base
 
     protected function getAdapterType(): string
     {
-        return this->object->getType();
+        return $this->object->getType();
     }
 
     protected function getAdapterDescription(): string

--- a/tests/Storage/Device/LocalTest.php
+++ b/tests/Storage/Device/LocalTest.php
@@ -26,6 +26,11 @@ class LocalTest extends TestCase
         $this->assertEquals($this->object->getName(), 'Local Storage');
     }
 
+    public function testType()
+    {
+        $this->assertEquals($this->object->getType(), 'local');
+    }
+
     public function testDescription()
     {
         $this->assertEquals($this->object->getDescription(), 'Adapter for Local storage that is in the physical or virtual machine or mounted to it.');

--- a/tests/Storage/Device/S3Test.php
+++ b/tests/Storage/Device/S3Test.php
@@ -26,6 +26,11 @@ class S3Test extends S3Base
         return 'S3 Storage';
     }
 
+    protected function getAdapterType(): string
+    {
+        return this->object->getType();
+    }
+
     protected function getAdapterDescription(): string
     {   
         return 'S3 Bucket Storage drive for AWS or on premise solution';

--- a/tests/Storage/Device/S3Test.php
+++ b/tests/Storage/Device/S3Test.php
@@ -28,7 +28,7 @@ class S3Test extends S3Base
 
     protected function getAdapterType(): string
     {
-        return this->object->getType();
+        return $this->object->getType();
     }
 
     protected function getAdapterDescription(): string

--- a/tests/Storage/Device/WasabiTest.php
+++ b/tests/Storage/Device/WasabiTest.php
@@ -24,7 +24,7 @@ class WasabiTest extends S3Base
 
     protected function getAdapterType(): string
     {
-        return this->object->getType();
+        return $this->object->getType();
     }
 
     protected function getAdapterDescription(): string

--- a/tests/Storage/Device/WasabiTest.php
+++ b/tests/Storage/Device/WasabiTest.php
@@ -22,6 +22,11 @@ class WasabiTest extends S3Base
         return 'Wasabi Storage';
     }
 
+    protected function getAdapterType(): string
+    {
+        return this->object->getType();
+    }
+
     protected function getAdapterDescription(): string
     {
         return 'Wasabi Storage';

--- a/tests/Storage/S3Base.php
+++ b/tests/Storage/S3Base.php
@@ -61,6 +61,11 @@ abstract class S3Base extends TestCase
         $this->assertEquals( $this->getAdapterName(), $this->object->getName());
     }
 
+    public function testType()
+    {
+        $this->assertEquals($this->object->getAdapterType(), $this->object->getType());
+    }
+
     public function testDescription()
     {
         $this->assertEquals($this->getAdapterDescription(), $this->object->getDescription());

--- a/tests/Storage/S3Base.php
+++ b/tests/Storage/S3Base.php
@@ -63,7 +63,7 @@ abstract class S3Base extends TestCase
 
     public function testType()
     {
-        $this->assertEquals($this->object->getAdapterType(), $this->object->getType());
+        $this->assertEquals($this->getAdapterType(), $this->object->getType());
     }
 
     public function testDescription()


### PR DESCRIPTION
Currently there is no way to get the type of a device since the device class does not expose any methods for it.

The existing getName function does not return a constant string that we can use in the consuming code. Hence we introduce a new method.  