### PR TITLE
Fix docker build for snappy extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN git clone --recursive --depth 1 --branch $PHP_ZSTD_VERSION https://github.co
 
 ## Snappy Extension
 FROM compile AS snappy
-RUN git clone --recursive --depth 1 https://github.com/kjdev/php-ext-snappy.git \
+RUN git clone --recursive https://github.com/kjdev/php-ext-snappy.git \
   && cd php-ext-snappy \
   && git checkout $PHP_SNAPPY_VERSION \
   && phpize \


### PR DESCRIPTION
The dependent repo updated so the --depth flag didn't fetch the correct commit hash. This removes the --depth flag so that all the commit history is pulled ensuring we pull the required commit hash.