### PR TITLE
feat: S3Compatible storage adapter

### DIFF
--- a/src/Storage/Device/S3.php
+++ b/src/Storage/Device/S3.php
@@ -3,7 +3,6 @@
 namespace Utopia\Storage\Device;
 
 use Exception;
-use function ltrim;
 use Utopia\Storage\Device;
 use Utopia\Storage\Storage;
 
@@ -484,7 +483,7 @@ class S3 extends Device
         ];
 
         if ($this->vhost) {
-            $parameters['prefix'] = ltrim($prefix, '/'); /** S3 specific requirement that prefix should never contain a leading slash */
+            $parameters['prefix'] = \ltrim($prefix, '/'); /** S3 specific requirement that prefix should never contain a leading slash */
         }
 
         if (! empty($continuationToken)) {

--- a/src/Storage/Device/S3.php
+++ b/src/Storage/Device/S3.php
@@ -3,10 +3,9 @@
 namespace Utopia\Storage\Device;
 
 use Exception;
+use function ltrim;
 use Utopia\Storage\Device;
 use Utopia\Storage\Storage;
-
-use function ltrim;
 
 class S3 extends Device
 {
@@ -458,8 +457,8 @@ class S3 extends Device
     {
         $base = '/';
 
-        if(!$this->vhost) {
-            return $base . $this->getBucket();
+        if (! $this->vhost) {
+            return $base.$this->getBucket();
         } else {
             return $base;
         }
@@ -484,7 +483,7 @@ class S3 extends Device
             'max-keys' => $maxKeys,
         ];
 
-        if($this->vhost) {
+        if ($this->vhost) {
             $parameters['prefix'] = ltrim($prefix, '/'); /** S3 specific requirement that prefix should never contain a leading slash */
         }
 

--- a/src/Storage/Device/S3.php
+++ b/src/Storage/Device/S3.php
@@ -457,10 +457,10 @@ class S3 extends Device
     {
         $base = '/';
 
-        if (! $this->vhost) {
-            return $base.$this->getBucket();
-        } else {
+        if ($this->vhost) {
             return $base;
+        } else {
+            return $base.$this->getBucket();
         }
     }
 

--- a/src/Storage/Device/S3Compatible.php
+++ b/src/Storage/Device/S3Compatible.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utopia\Storage\Device;
+
+use function preg_replace;
+use Utopia\Storage\Storage;
+
+/**
+ * Adapter for S3-Compatible storage providers
+ *
+ * Endpoint URL is explicitly defined by the caller due to providers allowing
+ * path-style or vhost-style endpoints as well as extra parameters such as
+ * client ID.
+ */
+class S3Compatible extends S3
+{
+    /**
+     * @var string
+     */
+    protected string $endpoint;
+
+    /**
+     * S3Compatible Constructor
+     *
+     * @param  string  $endpoint
+     * @param  string  $root
+     * @param  string  $accessKey
+     * @param  string  $secretKey
+     * @param  string  $bucket
+     * @param  bool  $vhost
+     * @param  string  $region
+     * @param  string  $acl
+     */
+    public function __construct(string $endpoint, string $root, string $accessKey, string $secretKey, string $bucket, bool $vhost, string $region = self::US_EAST_1, string $acl = self::ACL_PRIVATE)
+    {
+        if (! $vhost) {
+            $root = $bucket.$root;
+        }
+        parent::__construct($root, $accessKey, $secretKey, $bucket, $region, $acl);
+
+        $this->endpoint = $endpoint;
+        $this->vhost = $vhost;
+
+        /**
+         * Workaround to prevent having to do a refactor of
+         * the S3 class along with adapter addition. Class only
+         * supports https for the time being.
+         *
+         * There are multiple endpoint styles dependent upon the provider
+         * used. Examples are:
+         * <scheme>://<endpoint.url>/<bucket>
+         * <scheme>://<clientid.endpoint.url>/<bucket>
+         * <scheme>://<bucketvhost.endpoint.url>
+         */
+        $endpoint = preg_replace('/^https?:\/\//i', '', $endpoint);
+        $this->headers['host'] = $endpoint;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'S3-Compatible Storage';
+    }
+
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return Storage::DEVICE_S3COMPATIBLE;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return 'Generic Connector For S3-Compatible Storage Providers';
+    }
+}

--- a/src/Storage/Device/S3Compatible.php
+++ b/src/Storage/Device/S3Compatible.php
@@ -1,10 +1,7 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Utopia\Storage\Device;
 
-use function preg_replace;
 use Utopia\Storage\Storage;
 
 /**
@@ -54,7 +51,7 @@ class S3Compatible extends S3
          * <scheme>://<clientid.endpoint.url>/<bucket>
          * <scheme>://<bucketvhost.endpoint.url>
          */
-        $endpoint = preg_replace('/^https?:\/\//i', '', $endpoint);
+        $endpoint = \preg_replace('/^https?:\/\//i', '', $endpoint);
         $this->headers['host'] = $endpoint;
     }
 

--- a/src/Storage/Storage.php
+++ b/src/Storage/Storage.php
@@ -21,6 +21,8 @@ class Storage
 
     const DEVICE_LINODE = 'linode';
 
+    const DEVICE_S3COMPATIBLE = 's3compatible';
+
     /**
      * Devices.
      *

--- a/tests/Storage/Device/S3CompatibleTest.php
+++ b/tests/Storage/Device/S3CompatibleTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Utopia\Tests\Storage\Device;
 
 use Utopia\Storage\Device\S3Compatible;

--- a/tests/Storage/Device/S3CompatibleTest.php
+++ b/tests/Storage/Device/S3CompatibleTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utopia\Tests\Storage\Device;
+
+use Utopia\Storage\Device\S3Compatible;
+use Utopia\Tests\Storage\S3Base;
+
+class S3CompatibleTest extends S3Base
+{
+    protected function init(): void
+    {
+        $root = '/root';
+        $endpoint = $_SERVER['S3COMPATIBLE_ENDPOINT'] ?? '';
+        $vhost = $_SERVER['S3COMPATIBLE_VHOST'] === 'true';
+        $this->vhost = $vhost;
+        $key = $_SERVER['S3COMPATIBLE_ACCESS_KEY'] ?? '';
+        $secret = $_SERVER['S3COMPATIBLE_SECRET'] ?? '';
+        $bucket = $_SERVER['S3COMPATIBLE_BUCKET'] ?? 'appwrite-test-bucket';
+        $region = $_SERVER['S3COMPATIBLE_REGION'] ?? '';
+
+        if ($vhost) {
+            $this->root = $root;
+        } else {
+            $this->root = $bucket.$root;
+        }
+
+        $this->object = new S3Compatible($endpoint, $root, $key, $secret, $bucket, $vhost, $region);
+    }
+
+    /**
+     * @return string
+     */
+    public function getAdapterName(): string
+    {
+        return $this->object->getName();
+    }
+
+    /**
+     * @return string
+     */
+    public function getAdapterType(): string
+    {
+        return $this->object->getType();
+    }
+
+    /**
+     * @return string
+     */
+    public function getAdapterDescription(): string
+    {
+        return $this->object->getDescription();
+    }
+}

--- a/tests/Storage/S3Base.php
+++ b/tests/Storage/S3Base.php
@@ -29,6 +29,11 @@ abstract class S3Base extends TestCase
      */
     protected $root = '/root';
 
+    /**
+     * @var bool
+     */
+    protected $vhost = true;
+
     public function setUp(): void
     {
         $this->init();
@@ -138,12 +143,18 @@ abstract class S3Base extends TestCase
 
     public function testDeletePath()
     {
+        if ($this->vhost) {
+            $dpParam = 'bucket';
+        } else {
+            $dpParam = '';
+        }
+
         // Test Single Object
         $path = $this->object->getPath('text-for-delete-path.txt');
         $path = str_ireplace($this->object->getRoot(), $this->object->getRoot().DIRECTORY_SEPARATOR.'bucket', $path);
         $this->assertEquals(true, $this->object->write($path, 'Hello World', 'text/plain'));
         $this->assertEquals(true, $this->object->exists($path));
-        $this->assertEquals(true, $this->object->deletePath('bucket'));
+        $this->assertEquals(true, $this->object->deletePath($dpParam));
         $this->assertEquals(false, $this->object->exists($path));
 
         // Test Multiple Objects
@@ -157,7 +168,7 @@ abstract class S3Base extends TestCase
         $this->assertEquals(true, $this->object->write($path2, 'Hello World', 'text/plain'));
         $this->assertEquals(true, $this->object->exists($path2));
 
-        $this->assertEquals(true, $this->object->deletePath('bucket'));
+        $this->assertEquals(true, $this->object->deletePath($dpParam));
         $this->assertEquals(false, $this->object->exists($path));
         $this->assertEquals(false, $this->object->exists($path2));
     }


### PR DESCRIPTION
### Description
The following PR creates a generic S3-Compatible storage adapter that extends the Utopia\Storage\Device\S3 class in order to provide for customized endpoints in vhost-style or path-style storage access.

### Addressed Issue
This PR addresses #28 and attempts to do so using a least-intrusive method for code change.  Scope was limited, as much as possible, to the implementation of the S3Compatible adapter.  Other additions, modifications, or refactors that I may be able to address will have their own separate issues/PRs opened.

### Change Details
Attempts were made to limit excess code modification. Several considerations had to be taken into account for this change:

- Endpoint parameter should be configured as https://end.point without bucket suffix regardless of vhost/path styles. The S3Compatible class only supports https endpoints at the moment. This is a constraint related to the S3::call() method that would require more significant refactoring.
- Vhost parameter is a simple boolean: true for vhost-style, false for path-style. Parameter brought down to S3 class and defaults to true in order to facilitate vhost vs. path styles for S3Compatible.
- S3::listObjects() and S3::deletePath required modification to support vhost vs. path - there was no workaround for this.
- tests\S3Base::testDeletePath() modified to support vhost vs. path.
- Limitations due to current code (e.g. URI generation in S3::call() method) would need to be further addressed by other PR(s).

### Tests
- Unit tests available in Utopia\Tests\Storage\Device\S3CompatibleTest.
- I tested against systems I have access to: MinIO, DigitalOcean Spaces, and Backblaze B2.
- Tested path-style against MinIO, vhost-style against the others.
- For S3CompatibleTest specifically, all tests returned OK (21 tests, 49 assertions).