### PR TITLE
fix: accept lowercase file extensions

### DIFF
--- a/src/Storage/Validator/FileExt.php
+++ b/src/Storage/Validator/FileExt.php
@@ -46,6 +46,7 @@ class FileExt extends Validator
     public function isValid($filename): bool
     {
         $ext = pathinfo($filename, PATHINFO_EXTENSION);
+        $ext = strtolower($ext)
 
         if (! in_array($ext, $this->allowed)) {
             return false;

--- a/src/Storage/Validator/FileExt.php
+++ b/src/Storage/Validator/FileExt.php
@@ -46,7 +46,7 @@ class FileExt extends Validator
     public function isValid($filename): bool
     {
         $ext = pathinfo($filename, PATHINFO_EXTENSION);
-        $ext = strtolower($ext)
+        $ext = strtolower($ext);
 
         if (! in_array($ext, $this->allowed)) {
             return false;

--- a/tests/Storage/Validator/FileExtTest.php
+++ b/tests/Storage/Validator/FileExtTest.php
@@ -35,5 +35,6 @@ class FileExtTest extends TestCase
         $this->assertEquals($this->object->isValid('file.tar.g'), false);
         $this->assertEquals($this->object->isValid('file.tar.gz'), true);
         $this->assertEquals($this->object->isValid('file.gz'), true);
+        $this->assertEquals($this->object->isValid('file.GIF'), true);
     }
 }


### PR DESCRIPTION
Cameras and other media sources often output uppercase extensions such as 'JPG'.

These extensions should also be accepted.