### PR TITLE
Feat 3996 bzip2 compression

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "ext-brotli": "*",
         "ext-lz4": "*",
         "ext-snappy": "*",
+        "ext-bz2":"*",
         "php": ">=8.0",
         "utopia-php/framework": "0.*.*",
         "utopia-php/system": "0.*.*"

--- a/src/Storage/Compression/Algorithms/BZIP2.php
+++ b/src/Storage/Compression/Algorithms/BZIP2.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Utopia\Storage\Compression\Algorithms;
+
+use Utopia\Storage\Compression\Compression;
+
+class BZIP2 extends Compression
+{
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'bzip2';
+    }
+
+    /**
+     * Compress.
+     *
+     * @see https://www.php.net/manual/en/function.bzcompress.php
+     *
+     * @param string $data
+     * @return string
+     */
+    public function compress(string $data): string
+    {
+        return \bzcompress($data);
+    }
+
+    /**
+     * Decompress.
+     *
+     * @see https://www.php.net/manual/en/function.bzdecompress.php
+     *
+     * @param string $data
+     * @return string
+     */
+    public function decompress(string $data):string
+    {
+        return \bzdecompress($data);
+    }
+}

--- a/tests/Storage/Compression/Algorithms/BZIP2TEST.php
+++ b/tests/Storage/Compression/Algorithms/BZIP2TEST.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Utopia\Tests\Storage\Compression\Algorithms;
+use Utopia\Storage\Compression\Algorithms\BZIP2;
+use PHPUnit\Framework\TestCase;
+
+class BZIP2Test extends TestCase
+{
+    /** @var BZIP2 */
+    protected BZIP2 $object;
+
+    public function setUp(): void
+    {
+        $this->object = new BZIP2();
+    }
+
+    public function testName()
+    {
+        $this->assertEquals($this->object->getName(), 'bzip2');
+    }
+
+    public function testCompressDecompressWithText()
+    {
+        $demo = 'This is a demo string';
+        $demoSize = mb_strlen($demo, '8bit');
+
+        $data = $this->object->compress($demo);
+        $dataSize = mb_strlen($data, '8bit');
+
+        $this->assertEquals($demoSize, 21);
+        $this->assertEquals($dataSize, 58);
+
+        $this->assertEquals($this->object->decompress($data), $demo);
+    }
+
+    public function testCompressDecompressWithJPGImage()
+    {
+        $demo = \file_get_contents(__DIR__ . '/../../../resources/disk-a/kitten-1.jpg');
+        $demoSize = mb_strlen($demo, '8bit');
+
+        $data = $this->object->compress($demo);
+        $dataSize = mb_strlen($data, '8bit');
+
+        $this->assertEquals($demoSize, 599639);
+        $this->assertEquals($dataSize, 598565);
+
+        $this->assertGreaterThan($dataSize, $demoSize);
+
+        $data = $this->object->decompress($data);
+        $dataSize = mb_strlen($data, '8bit');
+
+        $this->assertEquals($dataSize, 599639);
+    }
+
+    public function testCompressDecompressWithPNGImage()
+    {
+        $demo = \file_get_contents(__DIR__ . '/../../../resources/disk-b/kitten-1.png');
+        $demoSize = mb_strlen($demo, '8bit');
+
+        $data = $this->object->compress($demo);
+        $dataSize = mb_strlen($data, '8bit');
+
+        $this->assertEquals($demoSize, 3038056);
+        $this->assertEquals($dataSize, 2999345);
+
+        $this->assertGreaterThan($dataSize, $demoSize);
+
+        $data = $this->object->decompress($data);
+        $dataSize = mb_strlen($data, '8bit');
+
+        $this->assertEquals($dataSize, 3038056);
+    }
+}


### PR DESCRIPTION
# Create BZIP2 Compression Class and Unit Test

## Description

This pull request introduces a new compression class to support BZIP2 compression and decompression, along with its accompanying unit test. The BZIP2 compression algorithm is now available for use in our storage library, enhancing its capabilities.

## Installation Instructions (for Linux-based distributions)

Before using the BZIP2 compression class, you need to install the required dependency. You can do this using the following command on Linux-based distributions:

```shell
sudo apt install php-bz2
```

## Testing command

```shel
./vendor/bin/phpunit  ./tests/Storage/Compression/Algorithms/BZIP2TEST.php
```
 ## Attached Screenshot
 
![Screenshot_20231003_214438](https://github.com/utopia-php/storage/assets/119918405/945e09b9-3f08-4a75-a14a-3c92d45c07b6)

closes: https://github.com/appwrite/appwrite/issues/3996