### PR TITLE
Added Cloudian Storage Adapter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,8 @@ jobs:
         WASABI_SECRET: ${{ secrets.WASABI_SECRET }}
         BACKBLAZE_ACCESS_KEY: ${{ secrets.BACKBLAZE_ACCESS_KEY }}
         BACKBLAZE_SECRET: ${{ secrets.BACKBLAZE_SECRET }}
+        CLOUDIAN_ACCESS_KEY: ${{ secrets.CLOUDIAN_ACCESS_KEY }}
+        CLOUDIAN_SECRET: ${{ secrets.CLOUDIAN_SECRET }}
       run: |
         docker compose up -d
         sleep 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,3 +21,5 @@ services:
       - BACKBLAZE_SECRET
       - WASABI_ACCESS_KEY
       - WASABI_SECRET
+      - CLOUDIAN_ACCESS_KEY
+      - CLOUDIAN_SECRET

--- a/src/Storage/Device/Cloudian.php
+++ b/src/Storage/Device/Cloudian.php
@@ -2,8 +2,6 @@
 
 namespace Utopia\Storage\Device;
 
-use Exception;
-use Utopia\Storage\Device;
 use Utopia\Storage\Storage;
 
 class Cloudian extends S3

--- a/src/Storage/Device/Cloudian.php
+++ b/src/Storage/Device/Cloudian.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Utopia\Storage\Device;
+
+use Exception;
+use Utopia\Storage\Device;
+use Utopia\Storage\Storage;
+
+class Cloudian extends S3
+{
+    /**
+     * Cloudian Constructor
+     *
+     * @param  string  $root
+     * @param  string  $accessKey
+     * @param  string  $secretKey
+     * @param  string  $bucket
+     * @param  string  $region
+     * @param  string  $acl
+     */
+    public function __construct(string $root, string $accessKey, string $secretKey, string $bucket, string $region = self::US_EAST_1, string $acl = self::ACL_PRIVATE)
+    {
+        parent::__construct($root, $accessKey, $secretKey, $bucket, $region, $acl);
+        $this->headers['host'] = $bucket.'.'.'s3'.'.'.$region.'.cloudian.com';
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return 'Cloudian Storage';
+    }
+
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return Storage::DEVICE_CLOUDIAN;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return 'Cloudian Storage';
+    }
+}

--- a/src/Storage/Storage.php
+++ b/src/Storage/Storage.php
@@ -21,6 +21,8 @@ class Storage
 
     const DEVICE_LINODE = 'linode';
 
+    const DEVICE_CLOUDIAN = 'cloudian';
+
     /**
      * Devices.
      *

--- a/tests/Storage/Device/CloudianTest.php
+++ b/tests/Storage/Device/CloudianTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Utopia\Tests\Storage\Device;
+
+use Utopia\Storage\Device\Cloudian;
+use Utopia\Tests\Storage\S3Base;
+
+class CloudianTest extends S3Base
+{
+    protected function init(): void
+    {
+        $this->root = '/root';
+        $key = $_SERVER['CLOUDIAN_ACCESS_KEY'] ?? '';
+        $secret = $_SERVER['CLOUDIAN_SECRET'] ?? '';
+        $bucket = 'utopia-storage-tests';
+
+        $this->object = new Cloudian($this->root, $key, $secret, $bucket, Cloudian::EU_CENTRAL_1, Cloudian::ACL_PRIVATE);
+    }
+
+    protected function getAdapterName(): string
+    {
+        return 'Cloudian Storage';
+    }
+
+    protected function getAdapterType(): string
+    {
+        return $this->object->getType();
+    }
+
+    protected function getAdapterDescription(): string
+    {
+        return 'Cloudian Storage';
+    }
+}


### PR DESCRIPTION
## What does this PR do?
This PR implements Cloudian Storage adapter

## Test Plan
1. Download this repository & install necessary package by
```
composer install
```
2. To execute the Cloudian test suite, you will need certain below key. Please follow these steps:
Get S3_ACCESS_KEY, S3_SECRET, CLOUDIAN_ACCESS_KEY, CLOUDIAN_SECRET and add run using below commands
(I have implemented Cloudian Storage adapter based on S3. I searched on internet and found that Cloudian do supports S3)
```
S3_ACCESS_KEY="S3_ACCESS_KEY" S3_SECRET="S3_SECRET" CLOUDIAN_ACCESS_KEY="CLOUDIAN_ACCESS_KEY" CLOUDIAN_SECRET="CLOUDIAN_SECRET" ./vendor/bin/pint tests/Storage/Device/CloudianTest.php
```
3. Unit test case of Cloudian
```
./vendor/bin/phpunit tests/Storage/Device/CloudianTest.php
```

![image](https://github.com/utopia-php/storage/assets/30138146/21aa30f8-38a4-4042-a83c-b4695d00c9f1)

## Closes 
[#6411](https://github.com/appwrite/appwrite/issues/6411)

## Have you read the [Contributing Guidelines on issues](https://github.com/utopia-php/messaging/blob/master/CONTRIBUTING.md)?
Yes
