### PR TITLE
FIx: Symlink deletion

### DIFF
--- a/src/Storage/Device/Local.php
+++ b/src/Storage/Device/Local.php
@@ -339,7 +339,7 @@ class Local extends Device
             }
 
             \rmdir($path);
-        } elseif (\is_file($path)) {
+        } elseif (\is_file($path) || \is_link($path)) {
             return \unlink($path);
         }
 


### PR DESCRIPTION
Recursive folder delete did not delete symlinks on local device.

With this change, its properly deleted.