### PR TITLE
Fix scandir

### DIFF
--- a/src/Storage/Device/Local.php
+++ b/src/Storage/Device/Local.php
@@ -522,6 +522,9 @@ class Local extends Device
             $files[] = $file;
         }
 
+        /**
+         * Hidden files
+         */
         foreach (\glob($dir.DIRECTORY_SEPARATOR.'.[!.]*') as $file) {
             $files[] = $file;
         }

--- a/src/Storage/Device/Local.php
+++ b/src/Storage/Device/Local.php
@@ -364,7 +364,7 @@ class Local extends Device
 
         foreach ($files as $file) {
             if (is_dir($file)) {
-                $this->deletePath(\substr_replace($file, '', 0, \strlen($this->getRoot() . DIRECTORY_SEPARATOR)));
+                $this->deletePath(\substr_replace($file, '', 0, \strlen($this->getRoot().DIRECTORY_SEPARATOR)));
             } else {
                 $this->delete($file, true);
             }

--- a/src/Storage/Device/Local.php
+++ b/src/Storage/Device/Local.php
@@ -364,7 +364,6 @@ class Local extends Device
 
         foreach ($files as $file) {
             if (is_dir($file)) {
-                //$this->deletePath(\ltrim($file, $this->getRoot().DIRECTORY_SEPARATOR));
                 $this->deletePath(substr_replace($file, '', 0, strlen($this->getRoot())));
             } else {
                 $this->delete($file, true);
@@ -520,6 +519,10 @@ class Local extends Device
         $files = [];
 
         foreach (\glob($dir.DIRECTORY_SEPARATOR.'*') as $file) {
+            $files[] = $file;
+        }
+
+        foreach (\glob($dir.DIRECTORY_SEPARATOR.'.[!.]*') as $file) {
             $files[] = $file;
         }
 

--- a/src/Storage/Device/Local.php
+++ b/src/Storage/Device/Local.php
@@ -364,7 +364,7 @@ class Local extends Device
 
         foreach ($files as $file) {
             if (is_dir($file)) {
-                $this->deletePath(substr_replace($file, '', 0, strlen($this->getRoot())));
+                $this->deletePath(\substr_replace($file, '', 0, \strlen($this->getRoot() . DIRECTORY_SEPARATOR)));
             } else {
                 $this->delete($file, true);
             }

--- a/src/Storage/Device/Local.php
+++ b/src/Storage/Device/Local.php
@@ -364,15 +364,13 @@ class Local extends Device
 
         foreach ($files as $file) {
             if (is_dir($file)) {
-                $this->deletePath(\ltrim($file, $this->getRoot().DIRECTORY_SEPARATOR));
+                $this->deletePath(substr_replace($file, '', 0, strlen($this->getRoot())));
             } else {
                 $this->delete($file, true);
             }
         }
 
-        \rmdir($path);
-
-        return true;
+        return \rmdir($path);
     }
 
     /**
@@ -517,18 +515,11 @@ class Local extends Device
      */
     public function getFiles(string $dir, int $max = self::MAX_PAGE_SIZE, string $continuationToken = ''): array
     {
-        if (! (\str_ends_with($dir, DIRECTORY_SEPARATOR))) {
-            $dir .= DIRECTORY_SEPARATOR;
-        }
-
+        $dir = rtrim($dir, DIRECTORY_SEPARATOR);
         $files = [];
 
-        foreach (\scandir($dir) as $file) {
-            if ($file === '.' || $file === '..') {
-                continue;
-            }
-
-            $files[] = $dir.$file;
+        foreach (\glob($dir.'/*') as $file) {
+            $files[] = $file;
         }
 
         return $files;

--- a/src/Storage/Device/Local.php
+++ b/src/Storage/Device/Local.php
@@ -364,6 +364,7 @@ class Local extends Device
 
         foreach ($files as $file) {
             if (is_dir($file)) {
+                //$this->deletePath(\ltrim($file, $this->getRoot().DIRECTORY_SEPARATOR));
                 $this->deletePath(substr_replace($file, '', 0, strlen($this->getRoot())));
             } else {
                 $this->delete($file, true);

--- a/src/Storage/Device/Local.php
+++ b/src/Storage/Device/Local.php
@@ -518,7 +518,7 @@ class Local extends Device
         $dir = rtrim($dir, DIRECTORY_SEPARATOR);
         $files = [];
 
-        foreach (\glob($dir.'/*') as $file) {
+        foreach (\glob($dir.DIRECTORY_SEPARATOR.'*') as $file) {
             $files[] = $file;
         }
 


### PR DESCRIPTION
Looks like there is a bug with \scandir in the current version of PHP we are using, it always returns an empty array.
Introducing \glob method instead