### PR TITLE
fix: deletePath not working properly in Local

### DIFF
--- a/src/Storage/Device/Local.php
+++ b/src/Storage/Device/Local.php
@@ -370,7 +370,8 @@ class Local extends Device
 
         foreach ($files as $file) {
             if (is_dir($file)) {
-                $this->deletePath(\substr_replace($file, '', 0, \strlen($this->getRoot().DIRECTORY_SEPARATOR)));
+                $relativePath = \str_replace($this->getRoot().DIRECTORY_SEPARATOR, '', $file);
+                $this->deletePath($relativePath);
             } else {
                 $this->delete($file, true);
             }

--- a/src/Storage/Device/Local.php
+++ b/src/Storage/Device/Local.php
@@ -370,7 +370,7 @@ class Local extends Device
 
         foreach ($files as $file) {
             if (is_dir($file)) {
-                $relativePath = \str_replace($this->getRoot().DIRECTORY_SEPARATOR, '', $file);
+                $relativePath = \substr($file, \strlen($this->getRoot().DIRECTORY_SEPARATOR));
                 $this->deletePath($relativePath);
             } else {
                 $this->delete($file, true);

--- a/tests/Storage/Device/LocalTest.php
+++ b/tests/Storage/Device/LocalTest.php
@@ -379,28 +379,28 @@ class LocalTest extends TestCase
 
         // Test Nested Directory Structure (prevents "Directory not empty" errors)
         $nestedBucket = 'nested-bucket';
-        
+
         // Create nested structure: nested-bucket/sub1/sub2/ with files at each level
         $this->assertTrue($this->object->createDirectory($nestedBucket));
         $this->assertTrue($this->object->createDirectory($nestedBucket.DIRECTORY_SEPARATOR.'sub1'));
         $this->assertTrue($this->object->createDirectory($nestedBucket.DIRECTORY_SEPARATOR.'sub1'.DIRECTORY_SEPARATOR.'sub2'));
-        
+
         // Add files in nested directories
         $rootFile = $this->object->getPath('file1.txt');
         $rootFile = str_ireplace($this->object->getRoot(), $this->object->getRoot().DIRECTORY_SEPARATOR.$nestedBucket, $rootFile);
         $this->assertTrue($this->object->write($rootFile, 'Content 1', 'text/plain'));
-        
+
         $nestedFile = $this->object->getPath('file2.txt');
         $nestedFile = str_ireplace($this->object->getRoot(), $this->object->getRoot().DIRECTORY_SEPARATOR.$nestedBucket.DIRECTORY_SEPARATOR.'sub1'.DIRECTORY_SEPARATOR.'sub2', $nestedFile);
         $this->assertTrue($this->object->write($nestedFile, 'Content 2', 'text/plain'));
-        
+
         // Verify files exist
         $this->assertTrue($this->object->exists($rootFile));
         $this->assertTrue($this->object->exists($nestedFile));
-        
+
         // Delete entire nested structure - should work without "Directory not empty" error
         $this->assertTrue($this->object->deletePath($nestedBucket));
-        
+
         // Verify everything is deleted
         $this->assertFalse($this->object->exists($rootFile));
         $this->assertFalse($this->object->exists($nestedFile));

--- a/tests/Storage/Device/LocalTest.php
+++ b/tests/Storage/Device/LocalTest.php
@@ -376,6 +376,35 @@ class LocalTest extends TestCase
         $this->assertEquals(false, $this->object->exists($path));
         $this->assertEquals(false, $this->object->exists($path2));
         $this->assertEquals(false, $this->object->exists($path3));
+
+        // Test Nested Directory Structure (prevents "Directory not empty" errors)
+        $nestedBucket = 'nested-bucket';
+        
+        // Create nested structure: nested-bucket/sub1/sub2/ with files at each level
+        $this->assertTrue($this->object->createDirectory($nestedBucket));
+        $this->assertTrue($this->object->createDirectory($nestedBucket.DIRECTORY_SEPARATOR.'sub1'));
+        $this->assertTrue($this->object->createDirectory($nestedBucket.DIRECTORY_SEPARATOR.'sub1'.DIRECTORY_SEPARATOR.'sub2'));
+        
+        // Add files in nested directories
+        $rootFile = $this->object->getPath('file1.txt');
+        $rootFile = str_ireplace($this->object->getRoot(), $this->object->getRoot().DIRECTORY_SEPARATOR.$nestedBucket, $rootFile);
+        $this->assertTrue($this->object->write($rootFile, 'Content 1', 'text/plain'));
+        
+        $nestedFile = $this->object->getPath('file2.txt');
+        $nestedFile = str_ireplace($this->object->getRoot(), $this->object->getRoot().DIRECTORY_SEPARATOR.$nestedBucket.DIRECTORY_SEPARATOR.'sub1'.DIRECTORY_SEPARATOR.'sub2', $nestedFile);
+        $this->assertTrue($this->object->write($nestedFile, 'Content 2', 'text/plain'));
+        
+        // Verify files exist
+        $this->assertTrue($this->object->exists($rootFile));
+        $this->assertTrue($this->object->exists($nestedFile));
+        
+        // Delete entire nested structure - should work without "Directory not empty" error
+        $this->assertTrue($this->object->deletePath($nestedBucket));
+        
+        // Verify everything is deleted
+        $this->assertFalse($this->object->exists($rootFile));
+        $this->assertFalse($this->object->exists($nestedFile));
+        $this->assertFalse(file_exists($this->object->getRoot().DIRECTORY_SEPARATOR.$nestedBucket));
     }
 
     public function testGetFiles()


### PR DESCRIPTION

fixes: `Warning: rmdir(/tmp/executor-test-build-a5847102/src): Directory not empty in /usr/local/vendor/utopia-php/storage/src/Storage/Device/Local.php on line 380`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved recursive deletion in local storage so nested directories and their files are reliably removed. Fixes intermittent "Directory not empty" errors and ensures full cleanup when deleting a parent path. No public API changes.

- Tests
  - Added tests that exercise multi-level directory deletion to verify behavior and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->