### PR TITLE
fix: exists method to check for dirs

### DIFF
--- a/src/Storage/Device/S3.php
+++ b/src/Storage/Device/S3.php
@@ -630,10 +630,12 @@ class S3 extends Device
         } catch (\Throwable $th) {
             try {
                 $prefix = $this->getRoot().'/'.ltrim($path, '/');
+                
                 if (! empty($path) && ! str_ends_with($prefix, '/')) {
                     $prefix .= '/';
                 }
 
+                $prefix = ltrim($prefix, '/');
                 $objects = $this->listObjects($prefix, 1);
                 $count = (int) ($objects['KeyCount'] ?? 0);
 

--- a/src/Storage/Device/S3.php
+++ b/src/Storage/Device/S3.php
@@ -629,13 +629,17 @@ class S3 extends Device
             return true;
         } catch (\Throwable $th) {
             try {
-                $prefix = $this->getRoot().'/'.ltrim($path, '/');
+                $root = $this->getRoot();
+                if (str_starts_with($path, $root.'/') || str_starts_with($path, $root.'\\')) {
+                    $prefix = $path;
+                } else {
+                    $prefix = $root.'/'.ltrim($path, '/');
+                }
 
                 if (! empty($path) && ! str_ends_with($prefix, '/')) {
                     $prefix .= '/';
                 }
 
-                $prefix = ltrim($prefix, '/');
                 $objects = $this->listObjects($prefix, 1);
                 $count = (int) ($objects['KeyCount'] ?? 0);
 

--- a/src/Storage/Device/S3.php
+++ b/src/Storage/Device/S3.php
@@ -630,7 +630,7 @@ class S3 extends Device
         } catch (\Throwable $th) {
             try {
                 $prefix = $this->getRoot().'/'.ltrim($path, '/');
-                
+
                 if (! empty($path) && ! str_ends_with($prefix, '/')) {
                     $prefix .= '/';
                 }

--- a/src/Storage/Device/S3.php
+++ b/src/Storage/Device/S3.php
@@ -616,7 +616,7 @@ class S3 extends Device
     }
 
     /**
-     * Check if file exists
+     * Check if file or directory exists
      *
      * @param  string  $path
      * @return bool
@@ -625,11 +625,23 @@ class S3 extends Device
     {
         try {
             $this->getInfo($path);
-        } catch (\Throwable $th) {
-            return false;
-        }
 
-        return true;
+            return true;
+        } catch (\Throwable $th) {
+            try {
+                $prefix = $this->getRoot().'/'.ltrim($path, '/');
+                if (! empty($path) && ! str_ends_with($prefix, '/')) {
+                    $prefix .= '/';
+                }
+
+                $objects = $this->listObjects($prefix, 1);
+                $count = (int) ($objects['KeyCount'] ?? 0);
+
+                return $count > 0;
+            } catch (\Throwable $th2) {
+                return false;
+            }
+        }
     }
 
     /**

--- a/tests/Storage/Device/LocalTest.php
+++ b/tests/Storage/Device/LocalTest.php
@@ -84,6 +84,36 @@ class LocalTest extends TestCase
         $this->object->delete($this->object->getPath('text-for-test-exists.txt'));
     }
 
+    public function testDirectoryExists()
+    {
+        $this->assertEquals(false, $this->object->exists($this->object->getPath('nonexistent-directory')));
+        $this->assertEquals(false, $this->object->exists($this->object->getPath('nonexistent-directory/')));
+
+        $testDir = $this->object->getPath('test-directory-exists');
+        $this->assertTrue($this->object->createDirectory($testDir));
+        $this->assertEquals(true, $this->object->exists($testDir));
+        $this->assertEquals(true, $this->object->exists($testDir.'/'));
+
+        $nestedDir = $testDir.'/nested/deep/structure';
+        $this->assertTrue($this->object->createDirectory($nestedDir));
+        $this->object->write($nestedDir.'/test.txt', 'Hello World');
+
+        $this->assertEquals(true, $this->object->exists($testDir.'/nested'));
+        $this->assertEquals(true, $this->object->exists($testDir.'/nested/'));
+        $this->assertEquals(true, $this->object->exists($testDir.'/nested/deep'));
+        $this->assertEquals(true, $this->object->exists($testDir.'/nested/deep/'));
+        $this->assertEquals(true, $this->object->exists($nestedDir));
+        $this->assertEquals(true, $this->object->exists($nestedDir.'/'));
+
+        $this->assertEquals(true, $this->object->exists($nestedDir.'/test.txt'));
+
+        $this->object->delete($testDir, true);
+
+        $this->assertEquals(false, $this->object->exists($testDir));
+        $this->assertEquals(false, $this->object->exists($testDir.'/nested'));
+        $this->assertEquals(false, $this->object->exists($nestedDir));
+    }
+
     public function testMove()
     {
         $this->assertEquals($this->object->write($this->object->getPath('text-for-move.txt'), 'Hello World'), true);

--- a/tests/Storage/S3Base.php
+++ b/tests/Storage/S3Base.php
@@ -21,6 +21,11 @@ abstract class S3Base extends TestCase
     abstract protected function getAdapterDescription(): string;
 
     /**
+     * @return string
+     */
+    abstract protected function getAdapterType(): string;
+
+    /**
      * @var S3
      */
     protected $object = null;
@@ -137,6 +142,27 @@ abstract class S3Base extends TestCase
     {
         $this->assertEquals(true, $this->object->exists($this->object->getPath('testing/kitten-1.jpg')));
         $this->assertEquals(false, $this->object->exists($this->object->getPath('testing/kitten-5.jpg')));
+    }
+
+    public function testDirectoryExists()
+    {
+        $this->assertEquals(true, $this->object->exists($this->object->getPath('testing/')));
+
+        $this->assertEquals(false, $this->object->exists($this->object->getPath('nonexistent/')));
+
+        $this->object->write($this->object->getPath('nested/deep/structure/test.txt'), 'Hello World', 'text/plain');
+
+        $this->assertEquals(true, $this->object->exists($this->object->getPath('nested')));
+        $this->assertEquals(true, $this->object->exists($this->object->getPath('nested/deep')));
+        $this->assertEquals(true, $this->object->exists($this->object->getPath('nested/deep/structure')));
+
+        $this->assertEquals(true, $this->object->exists($this->object->getPath('nested/deep/structure/test.txt')));
+
+        $this->object->delete($this->object->getPath('nested/deep/structure/test.txt'));
+
+        $this->assertEquals(false, $this->object->exists($this->object->getPath('nested')));
+        $this->assertEquals(false, $this->object->exists($this->object->getPath('nested/deep')));
+        $this->assertEquals(false, $this->object->exists($this->object->getPath('nested/deep/structure')));
     }
 
     public function testMove()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cloud storage folder detection improved so directories are reliably recognized (with or without trailing slash); when direct metadata lookup fails, a fallback listing check ensures parity with local storage.

* **Tests**
  * Added automated tests covering directory existence for nested paths and mixed file/folder scenarios across storage adapters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->