### PR TITLE
fix: Allow hyphen and underscore in filename

### DIFF
--- a/src/Storage/Validator/FileName.php
+++ b/src/Storage/Validator/FileName.php
@@ -15,7 +15,7 @@ class FileName extends Validator
     }
 
     /**
-     * The file name can only contain "a-z", "A-Z", "0-9" and "-" and not empty.
+     * The file name can only contain "a-z", "A-Z", "0-9", ".", "-", and "_", and not empty.
      *
      * @param  mixed  $name
      * @return bool
@@ -30,7 +30,7 @@ class FileName extends Validator
             return false;
         }
 
-        if (! \preg_match('/^[a-zA-Z0-9.]+$/', $name)) {
+        if (! \ctype_alnum(\str_replace(['.', '-', '_'], '', $name))) {
             return false;
         }
 

--- a/tests/Storage/Validator/FileNameTest.php
+++ b/tests/Storage/Validator/FileNameTest.php
@@ -29,5 +29,8 @@ class FileNameTest extends TestCase
         $this->assertEquals($this->object->isValid('../test'), false);
         $this->assertEquals($this->object->isValid('test.png'), true);
         $this->assertEquals($this->object->isValid('test'), true);
+        $this->assertEquals($this->object->isValid('test-test'), true);
+        $this->assertEquals($this->object->isValid('test_test'), true);
+        $this->assertEquals($this->object->isValid('test.test-test_test'), true);
     }
 }


### PR DESCRIPTION
Allows hyphen and underscore as valid characters for filename

Related: https://github.com/appwrite/appwrite/pull/10501

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded filename validation to allow dashes (-) and underscores (_), in addition to letters, numbers, and dots.
  - Validation remains strict: only these characters are accepted; empty or non-text inputs are rejected.

- Tests
  - Updated test cases to cover newly accepted filename patterns (e.g., test-test, test_test, mixed combinations).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->