### PR TITLE
Update telemetry dependency constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ext-curl": "*",
         "ext-simplexml": "*",
         "utopia-php/system": "0.*.*",
-        "utopia-php/telemetry": "0.2.*",
+        "utopia-php/telemetry": "^0.4",
         "utopia-php/validators": "0.2.*"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9f44bb9a0a80b39745d42e3d5023a7e9",
+    "content-hash": "a1bf5e40fce160a496dea63e8e2463cc",
     "packages": [
         {
             "name": "brick/math",
@@ -1925,16 +1925,16 @@
         },
         {
             "name": "utopia-php/telemetry",
-            "version": "0.2.0",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/telemetry.git",
-                "reference": "9997ebf59bb77920a7223ad73d834a76b09152c3"
+                "reference": "e0630df7d8176833cd4882f78814a5b893dcb0e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/telemetry/zipball/9997ebf59bb77920a7223ad73d834a76b09152c3",
-                "reference": "9997ebf59bb77920a7223ad73d834a76b09152c3",
+                "url": "https://api.github.com/repos/utopia-php/telemetry/zipball/e0630df7d8176833cd4882f78814a5b893dcb0e0",
+                "reference": "e0630df7d8176833cd4882f78814a5b893dcb0e0",
                 "shasum": ""
             },
             "require": {
@@ -1974,9 +1974,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/telemetry/issues",
-                "source": "https://github.com/utopia-php/telemetry/tree/0.2.0"
+                "source": "https://github.com/utopia-php/telemetry/tree/0.4.0"
             },
-            "time": "2025-12-17T07:56:38+00:00"
+            "time": "2026-05-29T11:57:04+00:00"
         },
         {
             "name": "utopia-php/validators",


### PR DESCRIPTION
## Summary
- Bump `utopia-php/telemetry` from `0.2.*` to `^0.4`.
- Update `composer.lock` to resolve `utopia-php/telemetry` `0.4.0`.

## Why
Circuit breaker `0.3.1` uses the telemetry `0.4` lazy metric API. Keeping downstream libraries pinned to telemetry `0.2.*` allows Composer to resolve an incompatible runtime combination where `Counter::lazy()` / `Gauge::lazy()` are missing.

## Tests
- `composer validate --strict`
- `composer lint`
- `composer test` not available: no Composer test script
