### PR TITLE
Defer storage operation telemetry instrument

### DIFF
--- a/src/Storage/Device.php
+++ b/src/Storage/Device.php
@@ -65,9 +65,10 @@ abstract class Device
 
     public function setTelemetry(Telemetry $telemetry): void
     {
-        $this->storageOperationTelemetry = $telemetry->createHistogram(
-            'storage.operation',
-            's',
+        $this->storageOperationTelemetry = Histogram::lazy(
+            telemetry: $telemetry,
+            name: 'storage.operation',
+            unit: 's',
             advisory: ['ExplicitBucketBoundaries' => [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10]]
         );
     }

--- a/tests/Storage/StorageTest.php
+++ b/tests/Storage/StorageTest.php
@@ -5,7 +5,9 @@ namespace Utopia\Tests\Storage;
 use Exception;
 use PHPUnit\Framework\TestCase;
 use Utopia\Storage\Device\Local;
+use Utopia\Storage\Device\Telemetry;
 use Utopia\Storage\Storage;
+use Utopia\Telemetry\Adapter\Test as TestTelemetry;
 
 Storage::setDevice('disk-a', new Local(__DIR__.'/../resources/disk-a'));
 Storage::setDevice('disk-b', new Local(__DIR__.'/../resources/disk-b'));
@@ -41,5 +43,20 @@ class StorageTest extends TestCase
         $file = '/kitten-1.jpg';
         $device = Storage::getDevice('disk-a');
         $this->assertFalse($device->move($file, $file));
+    }
+
+    public function testStorageOperationTelemetryIsCreatedOnFirstRecord(): void
+    {
+        $telemetry = new TestTelemetry();
+        $underlying = new Local(__DIR__.'/../resources/disk-a');
+        $device = new Telemetry($telemetry, $underlying);
+        $path = $underlying->getPath('lorem.txt');
+
+        $this->assertArrayNotHasKey('storage.operation', $telemetry->histograms);
+
+        $device->exists($path);
+
+        $this->assertArrayHasKey('storage.operation', $telemetry->histograms);
+        $this->assertCount(1, $telemetry->histograms['storage.operation']->values);
     }
 }


### PR DESCRIPTION
## Summary
- Defer registration of the `storage.operation` histogram until the first measured storage operation.
- Keep the existing metric name, unit, bucket boundaries, and operation attributes unchanged.
- Add regression coverage for lazy storage operation telemetry creation.

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml --filter StorageOperationTelemetry`
- `./vendor/bin/phpunit --configuration phpunit.xml tests/Storage/StorageTest.php`
- `composer lint`

## Notes
- `./vendor/bin/phpunit --configuration phpunit.xml --testsuite unit` still reports existing environment/state failures in `LocalTest::testTransferLarge`, `LocalTest::testTransferSmall`, and `LocalTest::testGetFiles`; the new telemetry coverage passes.
